### PR TITLE
Add universe attribute to Odyssey

### DIFF
--- a/src/odyssey.py
+++ b/src/odyssey.py
@@ -5,12 +5,12 @@ class Odyssey():
 
     def __init__(self):
         Odyssey._instance_count += 1
+        self.universe = None
 
     def run_game(self):
         self.engage()
-        the_universe = self.retrieve_universe()
-        galactic_survey = the_universe.galactic_survey
-        starting_scene_index = self.select_starting_index(galactic_survey)
+        self.universe = self.retrieve_universe()
+        starting_scene_index = self.select_starting_index()
 
     def engage(self):
         command = ''
@@ -32,7 +32,9 @@ class Odyssey():
 
         return new_universe
 
-    def select_starting_index(self, survey):
+    def select_starting_index(self):
+        survey = self.universe.galactic_survey
+
         print("\n\nThe most recent galactic survey uncovered the following galaxies.\n")
         for index, name in survey:
             print(f"{(index + 1)}) {name}")

--- a/tests/test_odyssey.py
+++ b/tests/test_odyssey.py
@@ -12,6 +12,19 @@ def new_odyssey():
    # Teardown
    new_odyssey.value = None
 
+@pytest.fixture(autouse=True)
+def universe_fixture():
+   # Setup
+   universe_fixture = Universe()
+
+   yield universe_fixture
+
+   # Teardown
+   universe_fixture.value = None
+
+def test_odyssey_attributes_on_creation(new_odyssey):
+    assert new_odyssey.universe is None
+
 # TODO: Adapt test to focus only on engage method to prevent adding to mock_user_input as game expands
 def test_run_game_prompt_advances_only_with_correct_user_input(new_odyssey, mocker):
     # Arrange
@@ -25,6 +38,16 @@ def test_run_game_prompt_advances_only_with_correct_user_input(new_odyssey, mock
     assert mock_user_input.call_count == 4
     mock_retrieve_universe.assert_called_once()
 
+def test_run_game_triggers_universe_retrieval(new_odyssey, mocker):
+    # Arrange
+    mocker.patch('builtins.input', side_effect=['engage', '1'])
+
+    # Act
+    new_odyssey.run_game()
+
+    # Assert
+    assert isinstance(new_odyssey.universe, Universe)
+
 def test_retrieve_universe_output(new_odyssey, capsys):
     # Act
     new_odyssey.retrieve_universe()
@@ -34,48 +57,48 @@ def test_retrieve_universe_output(new_odyssey, capsys):
     assert captured.out.startswith("\n\nYour mission is to explore")
     assert captured.out.endswith("return home safely to share what you've learned.\n")
 
-def test_select_starting_index_output_user_input_valid(new_odyssey, mocker, capsys):
+def test_select_starting_index_output_user_input_valid(new_odyssey, universe_fixture, mocker, capsys):
     # Arrange
-    survey = Universe().galactic_survey
-    user_input = str(len(survey)) # user selects highest number displayed
+    survey_fixture = universe_fixture.galactic_survey
+    user_input = str(len(survey_fixture)) # user selects highest number displayed
     mocker.patch('builtins.input', side_effect=[user_input])
+    mocker.patch.object(new_odyssey, 'universe', universe_fixture)
 
     # Act
-    result = new_odyssey.select_starting_index(survey)
+    result = new_odyssey.select_starting_index()
     captured = capsys.readouterr()
 
     # Assert
-    assert captured.out.endswith(f"You're headed to Galaxy {user_input}: {survey[result][1]}.\n")
-    assert type(result) == int
-    assert result in range (0, len(survey))
+    assert captured.out.endswith(f"You're headed to Galaxy {user_input}: {survey_fixture[result][1]}.\n")
+    assert result == int(user_input) - 1
 
-def test_select_starting_index_output_user_input_invalid(new_odyssey, mocker, capsys):
+def test_select_starting_index_output_user_input_invalid(new_odyssey, universe_fixture, mocker, capsys):
     # Arrange
-    survey = Universe().galactic_survey
+    survey_fixture = universe_fixture.galactic_survey
     user_input = 'Galaxy 1' # cannot be parsed to int
     mocker.patch('builtins.input', side_effect=[user_input])
+    mocker.patch.object(new_odyssey, 'universe', universe_fixture)
 
     # Act
-    result = new_odyssey.select_starting_index(survey)
+    result = new_odyssey.select_starting_index()
     captured = capsys.readouterr()
 
     # Assert
-    assert captured.out.endswith(f"You're headed to Galaxy {result + 1}: {survey[result][1]}.\n")
-    assert type(result) == int
-    assert result in range (0, len(survey))
+    assert captured.out.endswith(f"You're headed to Galaxy {result + 1}: {survey_fixture[result][1]}.\n")
+    assert result == 0
 
 
-def test_select_starting_index_output_with_user_input_out_of_range(new_odyssey, mocker, capsys):
+def test_select_starting_index_output_with_user_input_out_of_range(new_odyssey, universe_fixture,mocker, capsys):
     # Arrange
-    survey = Universe().galactic_survey
-    user_input = len(survey) + 1
+    survey_fixture = universe_fixture.galactic_survey
+    user_input = len(survey_fixture) + 1
     mocker.patch('builtins.input', side_effect=[user_input])
+    mocker.patch.object(new_odyssey, 'universe', universe_fixture)
 
     # Act
-    result = new_odyssey.select_starting_index(survey)
+    result = new_odyssey.select_starting_index()
     captured = capsys.readouterr()
 
     # Assert
-    assert captured.out.endswith(f"You're headed to Galaxy {result + 1}: {survey[result][1]}.\n")
-    assert type(result) == int
-    assert result in range(0, len(survey))
+    assert captured.out.endswith(f"You're headed to Galaxy {result + 1}: {survey_fixture[result][1]}.\n")
+    assert result == 0


### PR DESCRIPTION
This PR extracts the universe to be available on the odyssey instance so that the universe is available for the duration of the game.

This PR also strengthens assertions on how the first scene is selected.